### PR TITLE
Fix mistake in scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - automated performance regression tests
 
 ## To run:
-Requires docker and docker-compose.
+Requires docker and docker compose.
 
 To start TDS (with no caching config), run all tests, and stop TDS:
 ```

--- a/run-all.sh
+++ b/run-all.sh
@@ -2,7 +2,7 @@
 
 cd tds/
 docker build -t thredds-performance-tests:5.5-SNAPSHOT .
-docker-compose up -d tds-no-caching
+docker compose up -d tds-no-caching
 
 until docker inspect --format "{{json .State.Health.Status }}" thredds-performance-tests-no-caching\
 | grep -m 1 "healthy"; do sleep 1 ; done
@@ -12,4 +12,4 @@ docker build -t performance-tests:latest .
 docker run --rm --network="host" -v ./results/:/usr/src/app/results/ performance-tests
 
 cd ../tds/
-docker-compose down
+docker compose down

--- a/tds/start-default.sh
+++ b/tds/start-default.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker-compose up -d tds-default
+docker compose up -d tds-default

--- a/tds/start-no-caching.sh
+++ b/tds/start-no-caching.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker-compose up -d tds-no-caching
+docker compose up -d tds-no-caching

--- a/tds/stop.sh
+++ b/tds/stop.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker-compose down
+docker compose down


### PR DESCRIPTION
This fixes a mistake in the scripts-- `docker compose` is the correct newer form and `docker-compose` is deprecated.