### PR TITLE
Fix docker compose port publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To stop:
 ```
 cd tests/
 docker build -t performance-tests:latest .
-docker run --rm -v ./results/:/usr/src/app/results/ performance-tests
+docker run --rm --network="host" -v ./results/:/usr/src/app/results/ performance-tests
 ```
 
 ### With local python environment

--- a/run-all.sh
+++ b/run-all.sh
@@ -15,7 +15,7 @@ docker cp thredds-performance-tests:/usr/local/tomcat/webapps/thredds/META-INF/M
 cd ../tests/
 mkdir -p results/
 docker build -t performance-tests:latest .
-docker run --rm -v ./results/:/usr/src/app/results/ --user $(id -u):$(id -g) performance-tests
+docker run --rm --network="host" -v ./results/:/usr/src/app/results/ --user $(id -u):$(id -g) performance-tests
 
 # stop tds
 cd ../tds/

--- a/tds/docker-compose.yml
+++ b/tds/docker-compose.yml
@@ -4,9 +4,9 @@ services:
   tds-default:
     image: thredds-performance-tests:5.5-SNAPSHOT
     ports:
-      - "8080:8080"
-      - "443:8443"
-      - "8443:8443"
+      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:443:8443"
+      - "127.0.0.1:8443:8443"
     container_name: thredds-performance-tests
     volumes:
       - ./thredds/catalog.xml:/usr/local/tomcat/content/thredds/catalog.xml:ro
@@ -20,9 +20,9 @@ services:
   tds-no-caching:
     image: thredds-performance-tests:5.5-SNAPSHOT
     ports:
-      - "8080:8080"
-      - "443:8443"
-      - "8443:8443"
+      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:443:8443"
+      - "127.0.0.1:8443:8443"
     container_name: thredds-performance-tests
     volumes:
       - ./thredds/catalog.xml:/usr/local/tomcat/content/thredds/catalog.xml:ro

--- a/tests/run.py
+++ b/tests/run.py
@@ -53,7 +53,7 @@ CONFIG_SCHEMA = {
     }
 }
 
-BASE_URL = "http://host.docker.internal:8080/thredds/"
+BASE_URL = "http://localhost:8080/thredds/"
 CONFIG_DIR = "./configs/"
 RESULTS_DIR = "./results/"
 VERSION_FILE = "./version/MANIFEST.MF"


### PR DESCRIPTION
 - Revert unneeded change from https://github.com/Unidata/thredds-performance-tests/pull/6
 - Prefix docker publish host port with 127.0.0.1